### PR TITLE
2.3中 max-match.py 框架 pickle.load 参数错误

### DIFF
--- a/2-python-practice/3-max-matching-word-segmentation/max-match.py
+++ b/2-python-practice/3-max-matching-word-segmentation/max-match.py
@@ -14,7 +14,7 @@ if __name__=="__main__":
         sys.exit(1)
 
     try:
-        dic = pickle.load(sys.argv[2])
+        dic = pickle.load(open(sys.argv[2]))
     except:
         print >> sys.stderr, "failed to load dict"
         sys.exit(1)


### PR DESCRIPTION
2.3中 max-match.py 框架 pickle.load 参数应为open()的文件。现在框架不能使用。
[参考链接](http://www.jb51.net/article/45165.htm)
commit: open file to load
